### PR TITLE
Multiple schemas

### DIFF
--- a/build/engine.js
+++ b/build/engine.js
@@ -91,7 +91,7 @@ var createReportFunction = function (reporter, ignoreMatchers) { return function
 function processDatabase(_a) {
     var connection = _a.connection, _b = _a.plugins, plugins = _b === void 0 ? [] : _b, rules = _a.rules, schemas = _a.schemas, _c = _a.ignores, ignores = _c === void 0 ? [] : _c;
     return __awaiter(this, void 0, void 0, function () {
-        var pluginRules, allRules, registeredRules, knexConfig, db, ignoreMatchers, _i, schemas_1, schema, report, extractedSchemaObject, schemaObject, mergedRules, _d, _e, ruleKey, _f, state, options;
+        var pluginRules, allRules, registeredRules, knexConfig, ignoreMatchers, _i, schemas_1, schema, report, db, extractedSchemaObject, schemaObject, mergedRules, _d, _e, ruleKey, _f, state, options;
         return __generator(this, function (_g) {
             switch (_g.label) {
                 case 0:
@@ -105,7 +105,6 @@ function processDatabase(_a) {
                         client: 'pg',
                         connection: connection,
                     };
-                    db = knex_1.default(knexConfig);
                     ignoreMatchers = ignores.map(function (i) { return function (rule, identifier) {
                         var ruleMatch;
                         if (i.rule) {
@@ -135,6 +134,7 @@ function processDatabase(_a) {
                     if (!(_i < schemas_1.length)) return [3 /*break*/, 4];
                     schema = schemas_1[_i];
                     report = createReportFunction(consoleReporter, ignoreMatchers);
+                    db = knex_1.default(knexConfig);
                     return [4 /*yield*/, extract_pg_schema_1.extractSchema(schema.name, db)];
                 case 2:
                     extractedSchemaObject = _g.sent();

--- a/example/.schemalintrc.js
+++ b/example/.schemalintrc.js
@@ -22,6 +22,9 @@ module.exports = {
     {
       name: 'public',
     },
+    {
+      name: 'information_schema',
+    },
   ],
 
   ignores: [

--- a/src/engine.js
+++ b/src/engine.js
@@ -56,7 +56,6 @@ export async function processDatabase({
     client: 'pg',
     connection,
   };
-  const db = knex(knexConfig);
 
   const ignoreMatchers = ignores.map(i => (rule, identifier) => {
     let ruleMatch;
@@ -91,6 +90,7 @@ export async function processDatabase({
   for (const schema of schemas) {
     const report = createReportFunction(consoleReporter, ignoreMatchers);
 
+    const db = knex(knexConfig);
     const extractedSchemaObject = await extractSchema(schema.name, db);
 
     const schemaObject = {


### PR DESCRIPTION
Fixes #2 

Simply just connects to the database for each schema since `extract-pg-schema` kills the connections. 

Also updated the example to use the `information_schema` to validate. Up for debate whether you want to keep that or not. Let me know. 

Output from success multiple schema run though 🎉
```
~/dev/projects/oss/schemalint on  master ⌚ 15:43:14
$ yarn run-example
yarn run v1.19.1
$ node build/cli -c ./example/.schemalintrc
schema-lint
Connecting to dvdrental on localhost
public.address.address: error prefer-text-to-varchar : Prefer text to varchar types
public.address.address2: error prefer-text-to-varchar : Prefer text to varchar types
public.address.district: error prefer-text-to-varchar : Prefer text to varchar types
public.address.postal_code: error prefer-text-to-varchar : Prefer text to varchar types
public.address.phone: error prefer-text-to-varchar : Prefer text to varchar types
public.category.name: error prefer-text-to-varchar : Prefer text to varchar types
public.country.country: error prefer-text-to-varchar : Prefer text to varchar types
public.customer.first_name: error prefer-text-to-varchar : Prefer text to varchar types
public.customer.last_name: error prefer-text-to-varchar : Prefer text to varchar types
public.customer.email: error prefer-text-to-varchar : Prefer text to varchar types
public.film.title: error prefer-text-to-varchar : Prefer text to varchar types
public.staff.first_name: error prefer-text-to-varchar : Prefer text to varchar types
public.staff.last_name: error prefer-text-to-varchar : Prefer text to varchar types
public.staff.email: error prefer-text-to-varchar : Prefer text to varchar types
public.staff.username: error prefer-text-to-varchar : Prefer text to varchar types
public.staff.password: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_features.feature_id: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_features.feature_name: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_features.sub_feature_id: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_features.sub_feature_name: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_features.is_supported: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_features.is_verified_by: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_features.comments: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_implementation_info.implementation_info_id: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_implementation_info.implementation_info_name: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_implementation_info.character_value: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_implementation_info.comments: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_languages.sql_language_source: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_languages.sql_language_year: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_languages.sql_language_conformance: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_languages.sql_language_integrity: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_languages.sql_language_implementation: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_languages.sql_language_binding_style: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_languages.sql_language_programming_language: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_packages.feature_id: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_packages.feature_name: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_packages.is_supported: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_packages.is_verified_by: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_packages.comments: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_parts.feature_id: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_parts.feature_name: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_parts.is_supported: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_parts.is_verified_by: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_parts.comments: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_sizing.sizing_name: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_sizing.comments: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_sizing_profiles.sizing_name: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_sizing_profiles.profile_id: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_sizing_profiles.comments: error prefer-text-to-varchar : Prefer text to varchar types
information_schema.sql_features: error name-inflection : Expected singular names, but 'sql_features' seems to be plural
information_schema.sql_languages: error name-inflection : Expected singular names, but 'sql_languages' seems to be plural
information_schema.sql_packages: error name-inflection : Expected singular names, but 'sql_packages' seems to be plural
information_schema.sql_parts: error name-inflection : Expected singular names, but 'sql_parts' seems to be plural
information_schema.sql_sizing_profiles: error name-inflection : Expected singular names, but 'sql_sizing_profiles' seems to be plural
information_schema._pg_foreign_data_wrappers: error name-inflection : Expected singular names, but '_pg_foreign_data_wrappers' seems to be plural
information_schema._pg_foreign_servers: error name-inflection : Expected singular names, but '_pg_foreign_servers' seems to be plural
information_schema._pg_foreign_table_columns: error name-inflection : Expected singular names, but '_pg_foreign_table_columns' seems to be plural
information_schema._pg_foreign_tables: error name-inflection : Expected singular names, but '_pg_foreign_tables' seems to be plural
information_schema._pg_user_mappings: error name-inflection : Expected singular names, but '_pg_user_mappings' seems to be plural
information_schema.administrable_role_authorizations: error name-inflection : Expected singular names, but 'administrable_role_authorizations' seems to be plural
information_schema.applicable_roles: error name-inflection : Expected singular names, but 'applicable_roles' seems to be plural
information_schema.attributes: error name-inflection : Expected singular names, but 'attributes' seems to be plural
information_schema.character_sets: error name-inflection : Expected singular names, but 'character_sets' seems to be plural
information_schema.check_constraints: error name-inflection : Expected singular names, but 'check_constraints' seems to be plural
information_schema.collations: error name-inflection : Expected singular names, but 'collations' seems to be plural
information_schema.column_options: error name-inflection : Expected singular names, but 'column_options' seems to be plural
information_schema.column_privileges: error name-inflection : Expected singular names, but 'column_privileges' seems to be plural
information_schema.columns: error name-inflection : Expected singular names, but 'columns' seems to be plural
information_schema.data_type_privileges: error name-inflection : Expected singular names, but 'data_type_privileges' seems to be plural
information_schema.domain_constraints: error name-inflection : Expected singular names, but 'domain_constraints' seems to be plural
information_schema.domains: error name-inflection : Expected singular names, but 'domains' seems to be plural
information_schema.element_types: error name-inflection : Expected singular names, but 'element_types' seems to be plural
information_schema.enabled_roles: error name-inflection : Expected singular names, but 'enabled_roles' seems to be plural
information_schema.foreign_data_wrapper_options: error name-inflection : Expected singular names, but 'foreign_data_wrapper_options' seems to be plural
information_schema.foreign_data_wrappers: error name-inflection : Expected singular names, but 'foreign_data_wrappers' seems to be plural
information_schema.foreign_server_options: error name-inflection : Expected singular names, but 'foreign_server_options' seems to be plural
information_schema.foreign_servers: error name-inflection : Expected singular names, but 'foreign_servers' seems to be plural
information_schema.foreign_table_options: error name-inflection : Expected singular names, but 'foreign_table_options' seems to be plural
information_schema.foreign_tables: error name-inflection : Expected singular names, but 'foreign_tables' seems to be plural
information_schema.parameters: error name-inflection : Expected singular names, but 'parameters' seems to be plural
information_schema.referential_constraints: error name-inflection : Expected singular names, but 'referential_constraints' seems to be plural
information_schema.role_column_grants: error name-inflection : Expected singular names, but 'role_column_grants' seems to be plural
information_schema.role_routine_grants: error name-inflection : Expected singular names, but 'role_routine_grants' seems to be plural
information_schema.role_table_grants: error name-inflection : Expected singular names, but 'role_table_grants' seems to be plural
information_schema.role_udt_grants: error name-inflection : Expected singular names, but 'role_udt_grants' seems to be plural
information_schema.role_usage_grants: error name-inflection : Expected singular names, but 'role_usage_grants' seems to be plural
information_schema.routine_privileges: error name-inflection : Expected singular names, but 'routine_privileges' seems to be plural
information_schema.routines: error name-inflection : Expected singular names, but 'routines' seems to be plural
information_schema.sequences: error name-inflection : Expected singular names, but 'sequences' seems to be plural
information_schema.table_constraints: error name-inflection : Expected singular names, but 'table_constraints' seems to be plural
information_schema.table_privileges: error name-inflection : Expected singular names, but 'table_privileges' seems to be plural
information_schema.tables: error name-inflection : Expected singular names, but 'tables' seems to be plural
information_schema.transforms: error name-inflection : Expected singular names, but 'transforms' seems to be plural
information_schema.triggered_update_columns: error name-inflection : Expected singular names, but 'triggered_update_columns' seems to be plural
information_schema.triggers: error name-inflection : Expected singular names, but 'triggers' seems to be plural
information_schema.udt_privileges: error name-inflection : Expected singular names, but 'udt_privileges' seems to be plural
information_schema.usage_privileges: error name-inflection : Expected singular names, but 'usage_privileges' seems to be plural
information_schema.user_defined_types: error name-inflection : Expected singular names, but 'user_defined_types' seems to be plural
information_schema.user_mapping_options: error name-inflection : Expected singular names, but 'user_mapping_options' seems to be plural
information_schema.user_mappings: error name-inflection : Expected singular names, but 'user_mappings' seems to be plural
information_schema.views: error name-inflection : Expected singular names, but 'views' seems to be plural

Suggested fix
ALTER TABLE "address" ALTER COLUMN "address" TYPE TEXT;
ALTER TABLE "address" ALTER COLUMN "address2" TYPE TEXT;
ALTER TABLE "address" ALTER COLUMN "district" TYPE TEXT;
ALTER TABLE "address" ALTER COLUMN "postal_code" TYPE TEXT;
ALTER TABLE "address" ALTER COLUMN "phone" TYPE TEXT;
ALTER TABLE "category" ALTER COLUMN "name" TYPE TEXT;
ALTER TABLE "country" ALTER COLUMN "country" TYPE TEXT;
ALTER TABLE "customer" ALTER COLUMN "first_name" TYPE TEXT;
ALTER TABLE "customer" ALTER COLUMN "last_name" TYPE TEXT;
ALTER TABLE "customer" ALTER COLUMN "email" TYPE TEXT;
ALTER TABLE "film" ALTER COLUMN "title" TYPE TEXT;
ALTER TABLE "staff" ALTER COLUMN "first_name" TYPE TEXT;
ALTER TABLE "staff" ALTER COLUMN "last_name" TYPE TEXT;
ALTER TABLE "staff" ALTER COLUMN "email" TYPE TEXT;
ALTER TABLE "staff" ALTER COLUMN "username" TYPE TEXT;
ALTER TABLE "staff" ALTER COLUMN "password" TYPE TEXT;
ALTER TABLE "sql_features" ALTER COLUMN "feature_id" TYPE TEXT;
ALTER TABLE "sql_features" ALTER COLUMN "feature_name" TYPE TEXT;
ALTER TABLE "sql_features" ALTER COLUMN "sub_feature_id" TYPE TEXT;
ALTER TABLE "sql_features" ALTER COLUMN "sub_feature_name" TYPE TEXT;
ALTER TABLE "sql_features" ALTER COLUMN "is_supported" TYPE TEXT;
ALTER TABLE "sql_features" ALTER COLUMN "is_verified_by" TYPE TEXT;
ALTER TABLE "sql_features" ALTER COLUMN "comments" TYPE TEXT;
ALTER TABLE "sql_implementation_info" ALTER COLUMN "implementation_info_id" TYPE TEXT;
ALTER TABLE "sql_implementation_info" ALTER COLUMN "implementation_info_name" TYPE TEXT;
ALTER TABLE "sql_implementation_info" ALTER COLUMN "character_value" TYPE TEXT;
ALTER TABLE "sql_implementation_info" ALTER COLUMN "comments" TYPE TEXT;
ALTER TABLE "sql_languages" ALTER COLUMN "sql_language_source" TYPE TEXT;
ALTER TABLE "sql_languages" ALTER COLUMN "sql_language_year" TYPE TEXT;
ALTER TABLE "sql_languages" ALTER COLUMN "sql_language_conformance" TYPE TEXT;
ALTER TABLE "sql_languages" ALTER COLUMN "sql_language_integrity" TYPE TEXT;
ALTER TABLE "sql_languages" ALTER COLUMN "sql_language_implementation" TYPE TEXT;
ALTER TABLE "sql_languages" ALTER COLUMN "sql_language_binding_style" TYPE TEXT;
ALTER TABLE "sql_languages" ALTER COLUMN "sql_language_programming_language" TYPE TEXT;
ALTER TABLE "sql_packages" ALTER COLUMN "feature_id" TYPE TEXT;
ALTER TABLE "sql_packages" ALTER COLUMN "feature_name" TYPE TEXT;
ALTER TABLE "sql_packages" ALTER COLUMN "is_supported" TYPE TEXT;
ALTER TABLE "sql_packages" ALTER COLUMN "is_verified_by" TYPE TEXT;
ALTER TABLE "sql_packages" ALTER COLUMN "comments" TYPE TEXT;
ALTER TABLE "sql_parts" ALTER COLUMN "feature_id" TYPE TEXT;
ALTER TABLE "sql_parts" ALTER COLUMN "feature_name" TYPE TEXT;
ALTER TABLE "sql_parts" ALTER COLUMN "is_supported" TYPE TEXT;
ALTER TABLE "sql_parts" ALTER COLUMN "is_verified_by" TYPE TEXT;
ALTER TABLE "sql_parts" ALTER COLUMN "comments" TYPE TEXT;
ALTER TABLE "sql_sizing" ALTER COLUMN "sizing_name" TYPE TEXT;
ALTER TABLE "sql_sizing" ALTER COLUMN "comments" TYPE TEXT;
ALTER TABLE "sql_sizing_profiles" ALTER COLUMN "sizing_name" TYPE TEXT;
ALTER TABLE "sql_sizing_profiles" ALTER COLUMN "profile_id" TYPE TEXT;
ALTER TABLE "sql_sizing_profiles" ALTER COLUMN "comments" TYPE TEXT;
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```