### PR TITLE
Added new built-in types rule preferring TIMESTAMPTZ over TIMESTAMP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue with the owner of this repository before making a change. 
+
+## Pull Request Process
+
+
+1. Update the appropriate README.md with details of changes to the interface, this includes new environment 
+   variables, exposed ports, useful file locations and container parameters.
+2. The owner of this repository will merge the Pull Request in a timely fashion once the addition has been reviewed.

--- a/example/.schemalintrc.js
+++ b/example/.schemalintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     'name-casing': ['error', 'snake'],
     'prefer-jsonb-to-json': ['error'],
     'prefer-text-to-varchar': ['error'],
+    'prefer-timestamptz-to-timestamp': ['error'],
     'name-inflection': ['error', 'singular'],
   },
 

--- a/example/README.md
+++ b/example/README.md
@@ -7,7 +7,10 @@ I've created a Docker image that hosts it so if you have Docker installed, you c
 ```
 npm run start-example-db
 ```
-
+First, run the build script in this folder with:
+```
+npm run build
+```
 Then, run the config file in this folder with:
 ```
 npm run run-example

--- a/src/rules/README.md
+++ b/src/rules/README.md
@@ -26,3 +26,10 @@ If you want to enforce singular or plural naming for your tables, this rule can 
 Which one to choose is a matter of great debate but in the end it comes down to personal preference. You can choose `'singular'`  or `'plural'`.
 
 
+## prefer-timestamp-to-timestamptz
+
+In Postgres when you insert a value into a `timestamptz` column, PostgreSQL converts the `timestamptz` value into a UTC value and stores the UTC value in the table, and when you query `timestamptz`
+from the database, PostgreSQL converts the UTC value back to the time value of the timezone set by the database server, the user, or the current database connection, whereas `timestamp` does not save any 
+timezone data. You can learn more here: [Understanding PostgreSQL Timestamp Data Types](https://www.postgresqltutorial.com/postgresql-timestamp/)
+
+    

--- a/src/rules/types.js
+++ b/src/rules/types.js
@@ -43,3 +43,27 @@ export const preferTextToVarchar = {
     );
   },
 };
+
+export const preferTimestamptz = {
+  name: 'prefer-timestamptz-to-timestamp',
+  docs: {
+    description: 'Prefer TIMESTAMPTZ to type TIMESTAMP because when you insert a value into a timestamptz column, PostgreSQL converts the timestamptz value into a UTC value and stores the UTC value in the table,\n' +
+        'and when you query timestamptz from the database, PostgreSQL converts the UTC value back to the time value of the timezone set by the database server, the user, or the current database connection',
+    url: 'https://www.postgresqltutorial.com/postgresql-timestamp/',
+  },
+  process({ schemaObject, report }) {
+    const validator = ({ name: tableName }) => ({ name: columnName, type }) => {
+      if (type === 'timestamp') {
+        report({
+          rule: this.name,
+          identifier: `${schemaObject.name}.${tableName}.${columnName}`,
+          message: 'Prefer TIMESTAMPTZ to type TIMESTAMP',
+          suggestedMigration: `ALTER TABLE "${tableName}" ALTER COLUMN "${columnName}" TYPE TIMESTAMPTZ;`,
+        });
+      }
+    };
+    schemaObject.tables.forEach(table =>
+        table.columns.forEach(validator(table))
+    );
+  },
+};


### PR DESCRIPTION
-Added new built in rule for preferring type timestamp over timestamptz, added it to the example, and updated the documentation on the rule in README.md
-Updated the README.md for the example, because running a build is now required before running the example works 
-Added a bare bones CONTRIBUTING.md 