### PR TITLE
Adding require-primary-key rule

### DIFF
--- a/src/rules/README.md
+++ b/src/rules/README.md
@@ -44,3 +44,15 @@ issues that serial columns have:
 - other slight weirdnesses because serial is some kind of special macro
 
 You can learn more here: [Identity Columns Explained](https://www.2ndquadrant.com/en/blog/postgresql-10-identity-columns/)
+
+## require-primary-key
+
+Identity tables that do not have a primary key defined. Tables can be ignored by passing the `ignorePattern` rule argument.
+
+```json
+ rules: {
+    'require-primary-key': ['error', {
+      ignorePattern: 'information_schema.*'
+    }],
+  },
+  ```

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,3 +1,4 @@
 export * from './types'
 export * from './nameCasing'
 export * from './nameInflection'
+export * from './requirePrimaryKey'

--- a/src/rules/requirePrimaryKey.js
+++ b/src/rules/requirePrimaryKey.js
@@ -1,0 +1,35 @@
+export const requirePrimaryKey = {
+  name: 'require-primary-key',
+  docs: {
+    description: 'Enforce primary key definition',
+    url:
+      'https://github.com/kristiandupont/schemalint/tree/master/src/rules#require-primary-key',
+  },
+  process({ options, schemaObject, report }) {
+    const ignorePatternsMatch =
+      options[0] && options[0].ignorePattern
+        ? new RegExp(options[0].ignorePattern)
+        : null;
+    console.log(`IGNORE PATTERN: ${JSON.stringify(options[0].ignorePattern)}`);
+    const validator = ({ tags, columns, name: tableName }) => {
+      const idColumns = columns.filter((c) => c.isPrimary);
+
+      if (idColumns.length < 1) {
+        report({
+          rule: this.name,
+          identifier: `${schemaObject.name}.${tableName}`,
+          message: `The table ${schemaObject.name}.${tableName} does not have a primary key defined";`,
+          suggestedMigration: `ALTER TABLE "${schemaObject.name}.${tableName}" ADD PRIMARY KEY (<primary key column or columns>)";`,
+        });
+      }
+    };
+    schemaObject.tables
+      .filter((table) => {
+        return (
+          !ignorePatternsMatch ||
+          !ignorePatternsMatch.test(`${schemaObject.name}.${table.name}`)
+        );
+      })
+      .forEach(validator);
+  },
+};

--- a/src/rules/requirePrimaryKey.js
+++ b/src/rules/requirePrimaryKey.js
@@ -10,7 +10,6 @@ export const requirePrimaryKey = {
       options[0] && options[0].ignorePattern
         ? new RegExp(options[0].ignorePattern)
         : null;
-    console.log(`IGNORE PATTERN: ${JSON.stringify(options[0].ignorePattern)}`);
     const validator = ({ tags, columns, name: tableName }) => {
       const idColumns = columns.filter((c) => c.isPrimary);
 


### PR DESCRIPTION
Added a rule to require primary keys to be defined on each table with an `ignorePattern` option to exclude tables if desired.