### PR TITLE
Prevent unhandled exception when requiring config file

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -57,9 +57,9 @@ async function main() {
     process.cwd(),
     options.config || '.schemalintrc.js'
   );
-  const config = require(configFile);
-
+  
   try {
+    const config = require(configFile);
     const exitCode = await processDatabase(config);
     process.exit(exitCode);
   } catch (error) {


### PR DESCRIPTION
Right now an unhandled exception is thrown when a config file is not found or contains syntax errors.