### PR TITLE
feat: support absolute or relative plugin paths

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -44,7 +44,7 @@ export async function processDatabase({
 }: Config): Promise<number> {
   const pluginRules = plugins.map(
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    (p) => require(path.join(process.cwd(), p)) as Record<string, Rule>,
+    (p) => require(path.resolve(p)) as Record<string, Rule>,
   );
   const allRules = [builtinRules, ...pluginRules].reduce(
     (acc, elem) => ({ ...acc, ...elem }),


### PR DESCRIPTION
Small fix to allow using absolute paths to import plugins, in addition to relative ones (which work identically to before). This should make it easier to reference plugins in more setups (e.g., when the file for a plugin needs to be looked up through `require.resolve`).